### PR TITLE
fixed podspecs for cocoapods v1.0

### DIFF
--- a/Specs/APFeed/3.5.1/APFeed.podspec
+++ b/Specs/APFeed/3.5.1/APFeed.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 	s.version = "3.5.1"
 
 	# The minimum deployment targets of the supported platforms
-	s.ios.platform = :ios
+	s.platform = :ios
 	s.ios.deployment_target = "7.0"
 
 	# A short (maximum 140 characters) description of the Pod

--- a/Specs/APFeed/3.5.2/APFeed.podspec
+++ b/Specs/APFeed/3.5.2/APFeed.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 	s.version = "3.5.2"
 
 	# The minimum deployment targets of the supported platforms
-	s.ios.platform = :ios
+	s.platform = :ios
 	s.ios.deployment_target = "7.0"
 
 	# A short (maximum 140 characters) description of the Pod

--- a/Specs/APFeed/3.5.3/APFeed.podspec
+++ b/Specs/APFeed/3.5.3/APFeed.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 	s.version = "3.5.3"
 
 	# The minimum deployment targets of the supported platforms
-	s.ios.platform = :ios
+	s.platform = :ios
 	s.ios.deployment_target = "7.0"
 
 	# A short (maximum 140 characters) description of the Pod

--- a/Specs/APFeed/3.5.4/APFeed.podspec
+++ b/Specs/APFeed/3.5.4/APFeed.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 	s.name = "APFeed"
 	s.version = "3.5.4"
 
-	s.ios.platform = :ios
+	s.platform = :ios
 	s.ios.deployment_target = "8.0"
 	s.summary = "APFeed"
 	s.description = "APFeed framework"

--- a/Specs/APFeed/3.5/APFeed.podspec
+++ b/Specs/APFeed/3.5/APFeed.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 	s.version = "3.5"
 
 	# The minimum deployment targets of the supported platforms
-	s.ios.platform = :ios
+	s.platform = :ios
 	s.ios.deployment_target = "7.0"
 
 	# A short (maximum 140 characters) description of the Pod

--- a/Specs/Applicaster/2.18.175/Applicaster.podspec
+++ b/Specs/Applicaster/2.18.175/Applicaster.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 	s.version = "2.18.175"
 
 	# The minimum deployment targets of the supported platforms
-	s.ios.platform = :ios
+	s.platform = :ios
 	s.ios.deployment_target = "7.0"
 
 	# A short (maximum 140 characters) description of the Pod

--- a/Specs/Applicaster/2.18.178/Applicaster.podspec
+++ b/Specs/Applicaster/2.18.178/Applicaster.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 	s.version = "2.18.178"
 
 	# The minimum deployment targets of the supported platforms
-	s.ios.platform = :ios
+	s.platform = :ios
 	s.ios.deployment_target = "7.0"
 
 	# A short (maximum 140 characters) description of the Pod

--- a/Specs/Applicaster/2.18.179/Applicaster.podspec
+++ b/Specs/Applicaster/2.18.179/Applicaster.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 	s.version = "2.18.179"
 
 	# The minimum deployment targets of the supported platforms
-	s.ios.platform = :ios
+	s.platform = :ios
 	s.ios.deployment_target = "7.0"
 
 	# A short (maximum 140 characters) description of the Pod

--- a/Specs/Applicaster/2.18.180/Applicaster.podspec
+++ b/Specs/Applicaster/2.18.180/Applicaster.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 	s.version = "2.18.180"
 
 	# The minimum deployment targets of the supported platforms
-	s.ios.platform = :ios
+	s.platform = :ios
 	s.ios.deployment_target = "7.0"
 
 	# A short (maximum 140 characters) description of the Pod

--- a/Specs/Applicaster/2.18.181/Applicaster.podspec
+++ b/Specs/Applicaster/2.18.181/Applicaster.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 	s.version = "2.18.181"
 
 	# The minimum deployment targets of the supported platforms
-	s.ios.platform = :ios
+	s.platform = :ios
 	s.ios.deployment_target = "7.0"
 
 	# A short (maximum 140 characters) description of the Pod

--- a/Specs/Applicaster/2.18.183/Applicaster.podspec
+++ b/Specs/Applicaster/2.18.183/Applicaster.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 	s.version = "2.18.183"
 
 	# The minimum deployment targets of the supported platforms
-	s.ios.platform = :ios
+	s.platform = :ios
 	s.ios.deployment_target = "7.0"
 
 	# A short (maximum 140 characters) description of the Pod

--- a/Specs/ApplicasterSDK/3.0.8/ApplicasterSDK.podspec
+++ b/Specs/ApplicasterSDK/3.0.8/ApplicasterSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 	s.name = "ApplicasterSDK"
 	s.version = "3.0.8"
-	s.ios.platform = :ios
+	s.platform = :ios
 	s.ios.deployment_target = "8.0"
 	s.summary = "ApplicasterSDK"
 	s.description = "ApplicasterSDK"


### PR DESCRIPTION
Hi Applicaster,
cocoapods released their final v1.0 and I made the necessary changes to the "APFeed" and "Applicaster" podspecs so that they are compatible again with the newest cocoapods release.
Would be happy if you could merge these changes.
Cheers,
Thomas